### PR TITLE
add default value with get method

### DIFF
--- a/src/onapsdk/msb/k8s/definition.py
+++ b/src/onapsdk/msb/k8s/definition.py
@@ -123,9 +123,9 @@ class Definition(DefinitionBase):
         return cls(
             definition["rb-name"],
             definition["rb-version"],
-            definition.get("chart-name"),
-            definition.get("description"),
-            definition.get("labels")
+            definition.get("chart-name", None),
+            definition.get("description", None),
+            definition.get("labels", None)
         )
 
     @classmethod

--- a/src/onapsdk/msb/k8s/definition.py
+++ b/src/onapsdk/msb/k8s/definition.py
@@ -123,9 +123,9 @@ class Definition(DefinitionBase):
         return cls(
             definition["rb-name"],
             definition["rb-version"],
-            definition.get("chart-name", None),
-            definition.get("description", None),
-            definition.get("labels", None)
+            definition.get("chart-name", "no chart-name"),
+            definition.get("description", "no description"),
+            definition.get("labels", "no label")
         )
 
     @classmethod


### PR DESCRIPTION
We recommended that you use a default argument so that if the value for your key is not found, a default value is returned.